### PR TITLE
alsa-sink: clear pollfd revents before poll

### DIFF
--- a/src/modules/alsa/alsa-sink.c
+++ b/src/modules/alsa/alsa-sink.c
@@ -1915,6 +1915,7 @@ static void thread_func(void *userdata) {
             unsigned n;
 
             pollfd = pa_rtpoll_item_get_pollfd(u->alsa_rtpoll_item, &n);
+            pollfd->revents = 0;
 
             if ((err = snd_pcm_poll_descriptors_revents(u->pcm_handle, pollfd, n, &revents)) < 0) {
                 pa_log("snd_pcm_poll_descriptors_revents() failed: %s", pa_alsa_strerror(err));


### PR DESCRIPTION
Always clear revents before calling snd_pcm_poll_descriptors_revents()
as the ALSA function will not clear out existing events.

Without this, playback restart fails in the following
scenario:

1. single stream PCM playback ongoing
2. system put to system suspend (S3), ALSA sink suspended
3. system resumes, ALSA sink restarted
4. upon first alsa-sink thread_func iteration, rtpoll
  revents still hass POLLERR bits set (due to the suspend)
5. execution goes to pa_alsa_recover_from_poll()
6. snd_pcm_drop() is called and PCM is restarted
7. process loops from (4) and playback is never recovered

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>